### PR TITLE
Changed length condition from 1 to 0

### DIFF
--- a/bankruptcy/utils.py
+++ b/bankruptcy/utils.py
@@ -125,7 +125,7 @@ def convert_pdf(filepath: str, temp_output: str, form: str) -> bool:
         t_page = PageObject.createBlankPage(None, width, height * (last - first + 1))
         length = last - first
 
-        if length == 1:
+        if length == 0:
             writer.addPage(page)
             with open(temp_output, "wb") as file:
                 writer.write(file)


### PR DESCRIPTION
I believe the length should be 0 here because a length of 1 means there are 2 pages. That means in the existing code, when there are 2 pages, only the first page will be added to the converted pdf. The second page will be deleted and replaced with a blank page.

In the modified code, the condition is only triggered when there is 1 page, and no content is lost.