### PR TITLE
Fix form page identification

### DIFF
--- a/bankruptcy/utils.py
+++ b/bankruptcy/utils.py
@@ -101,9 +101,10 @@ def convert_pdf(filepath: str, temp_output: str, form: str) -> bool:
     with pdfplumber.open(filepath) as pdf:
         for page in pdf.pages:
             text = page.extract_text()
-            if text[-300:].find(form) == -1:
-                continue
-            if text[-300:].lower().find("page") == -1:
+            pattern = r"(?<!\w)(?:\(|\b){}(?:\)|\b)(?!\w(.*Official Form))".format(
+                re.escape(form)
+            )
+            if not re.findall(pattern, text[-300:]):
                 continue
             pages.append(page.page_number - 1)
 
@@ -116,7 +117,7 @@ def convert_pdf(filepath: str, temp_output: str, form: str) -> bool:
 
         # Extract single page form and return it
         if len(pages) == 1:
-            writer.addPage(page)
+            writer.addPage(pdf.getPage(pages[0]))
             with open(temp_output, "wb") as file:
                 writer.write(file)
             print(f"Extracted {form}, on page {pages[0] - 1}")

--- a/bankruptcy/utils.py
+++ b/bankruptcy/utils.py
@@ -101,10 +101,9 @@ def convert_pdf(filepath: str, temp_output: str, form: str) -> bool:
     with pdfplumber.open(filepath) as pdf:
         for page in pdf.pages:
             text = page.extract_text()
-            pattern = r"(?<!\w)(?:\(|\b){}(?:\)|\b)(?!\w(.*Official Form))".format(
-                re.escape(form)
-            )
-            if not re.findall(pattern, text[-300:]):
+            pattern = r"{}(?:\)|\b)(?![\s\S]*Official Form)".format(re.escape(form))
+            matches = re.findall(pattern, text, re.MULTILINE)
+            if not matches:
                 continue
             pages.append(page.page_number - 1)
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -50,7 +50,6 @@ class BankruptcyTest(TestCase):
 
         self.assertTrue(success, msg="Accidentally extracted Official Form 106J")
 
-
     def test_can_we_handle_missing_checkboxes(self):
         """Can we handle partially bad PDF can still return content?"""
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 import os
 from glob import iglob
+from tempfile import NamedTemporaryFile
 from unittest import TestCase
 import sys
+
+from bankruptcy.utils import convert_pdf
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
@@ -28,6 +31,25 @@ class BankruptcyTest(TestCase):
         filepath = f"{self.root}/test_assets/gov.uscourts.orb.507503.11.0.pdf"
         results = extract_all(filepath=filepath)
         self.assertFalse(results)
+
+    def test_avoid_wrong_document(self):
+        """Can we avoid accidentally finding Form 119?"""
+
+        with NamedTemporaryFile(suffix=".pdf") as file:
+            filepath = f"{self.assets}/gov.uscourts.orb.473342.1.0.pdf"
+            success = convert_pdf(filepath, file.name, "Official Form 119")
+
+        self.assertFalse(success, msg="Accidentally found Form 119")
+
+    def test_extract_single_page_form(self):
+        """Can we extract single page form?"""
+
+        with NamedTemporaryFile(suffix=".pdf") as file:
+            filepath = f"{self.assets}/gov.uscourts.orb.473342.1.0.pdf"
+            success = convert_pdf(filepath, file.name, "Official Form 106G")
+
+        self.assertTrue(success, msg="Accidentally extracted Official Form 106J")
+
 
     def test_can_we_handle_missing_checkboxes(self):
         """Can we handle partially bad PDF can still return content?"""


### PR DESCRIPTION
Fix Issue #76 

@anthonysalvato3

Change how code identifies form page types. 

PR also adds a fix for the new pr that finds single page pdf forms
